### PR TITLE
Fix for inverse kinematics solver when specifying joint names.

### DIFF
--- a/robohive/utils/inverse_kinematics.py
+++ b/robohive/utils/inverse_kinematics.py
@@ -153,7 +153,7 @@ def qpos_from_site_pose(physics,
     # Find the indices of the DOFs belonging to each named joint. Note that
     # these are not necessarily the same as the joint IDs, since a single joint
     # may have >1 DOF (e.g. ball joints).
-    indexer = physics.named.model.dof_jntid.axes.row
+    indexer = physics.sim.named.model.dof_jntid.axes.row
     # `dof_jntid` is an `(nv,)` array indexed by joint name. We use its row
     # indexer to map each joint name to the indices of its corresponding DOFs.
     dof_indices = indexer.convert_key_item(joint_names)


### PR DESCRIPTION
IK Solver throws an error when specifying the joint_names.

```
indexer = physics.named.model.dof_jntid.axes.row
AttributeError: 'DMSimScene' object has no attribute 'named'
```

DMSimScene doesnt have the named param, only the underlying DM simulator does. And that is in `physics.sim`. 